### PR TITLE
Added HiFi PCM option (Disabled by default)

### DIFF
--- a/Board/mist/MIST_Toplevel.vhd
+++ b/Board/mist/MIST_Toplevel.vhd
@@ -142,6 +142,7 @@ constant CONF_STR : string :=
     "OA,Only 3 buttons,Off,On;"&
     "O3,VRAM Speed,Slow,Fast;"&
     "OD,Fake EEPROM,Off,On;"&
+    "OF,PCM HiFi sound,Disable,Enable;"&
     "O4,FM Sound,Enable,Disable;"&
     "O5,PSG Sound,Enable,Disable;"&
     "T0,Reset;";
@@ -315,6 +316,7 @@ ext_sw(7) <= status(9); --swap Y
 ext_sw(8) <= status(10); --3 buttons
 ext_sw(9) <= not status(3); -- VRAM speed emulation
 ext_sw(10) <= status(13); -- Fake EEPROM
+ext_sw(11) <= status(15); -- HiFi PCM
 
 --SDRAM_A(12)<='0';
 virtualtoplevel : entity work.Virtual_Toplevel

--- a/src/virtual_toplevel.vhd
+++ b/src/virtual_toplevel.vhd
@@ -103,6 +103,7 @@ entity Virtual_Toplevel is
 														  -- 8 - 3 Buttons only
 														  -- 9 - VRAM speed emu
 														  -- 10 - EEPROM emu (fake)
+														  -- 11 - HiFi PCM
 	);
 end entity;
 
@@ -362,6 +363,7 @@ signal FM_LEFT			: std_logic_vector(15 downto 0);
 signal FM_RIGHT		: std_logic_vector(15 downto 0);
 
 signal FM_ENABLE		: std_logic;
+signal FM_HIFI			: std_logic;
 
 -- PSG
 signal PSG_SEL			: std_logic;
@@ -804,6 +806,8 @@ port map(
 	wr_n	=> FM_RNW,
 	din		=> FM_DI,
 	dout	=> FM_DO,
+	-- Real time configuration
+	en_hifi_pcm => FM_HIFI,
 
 	snd_left  => FM_LEFT,
 	snd_right => FM_RIGHT
@@ -812,6 +816,7 @@ port map(
 -- Audio control
 PSG_ENABLE <= not SW(3);
 FM_ENABLE  <= not SW(4);
+FM_HIFI    <=     SW(11);
 
 genmix : jt12_genmix
 port map(


### PR DESCRIPTION
I have added PCM audio interpolation (as an option). It sounds much better for games with poor PCM samples, like Altered Beast or Street Fighter 2. For games with higher sampling rates like Streets of Rage the difference is minimal.

You can hear a sample [here](https://www.patreon.com/posts/26031511).